### PR TITLE
Improve secrets handling, fstab robustness, platform pinning, and Docker/Postgres defaults

### DIFF
--- a/containers.yml
+++ b/containers.yml
@@ -18,7 +18,7 @@
       vars:
         docker_postgres_port: 54321
         docker_postgres_volume: /home/docker/postgres
-        docker_postgres_password: secret
+        docker_postgres_password: "{{ vault_docker_postgres_password | mandatory }}"
       tags: docker_postgres
 
 - name: Implantação do Apache no contêiner AWS EC2

--- a/library/fstab.py
+++ b/library/fstab.py
@@ -136,6 +136,8 @@ def run_module():
         module.fail_json(msg="%s not found" % (fname))
     if not os.access(fname, os.R_OK):
         module.fail_json(msg="%s not readable" % (fname))
+    if not os.access(fname, os.W_OK):
+        module.fail_json(msg="%s not writable" % (fname))
 
     # 1. Open /etc/fstab file.
     with open(fname, "r+") as file:
@@ -143,11 +145,14 @@ def run_module():
         spec_exists = False
         # 2. Read each line of the file.
         for line in file:
-            # 3. Ignore comments.
-            if line[0] == '#':
+            # 3. Ignore comments and blank lines.
+            stripped = line.strip()
+            if not stripped or stripped.startswith('#'):
                 continue
             # 4. Split line into fields.
-            fields = line.split()
+            fields = stripped.split()
+            if not fields:
+                continue
             # 5. Check if spec already exists in /etc/fstab.
             if fields[0] == spec:
                 spec_exists = True

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,12 +9,12 @@ driver:
 
 platforms:
   - name: instance-debian
-    image: debian:latest
+    image: debian:12
     pre_built_image: true
     groups:
       - debian
   - name: instance-ubuntu
-    image: ubuntu:latest
+    image: ubuntu:24.04
     pre_built_image: true
     groups:
       - ubuntu

--- a/roles/user/tasks/linux.yml
+++ b/roles/user/tasks/linux.yml
@@ -14,7 +14,7 @@
   ansible.posix.authorized_key:
     user: "{{ item.name }}"
     state: present
-    key: "{{ lookup('file', 'files/{{ item.name }}.pub') }}"
+    key: "{{ lookup('file', role_path ~ '/files/' ~ item.name ~ '.pub') }}"
   loop: "{{ user_admins }}"
   when: user_admins is defined
   tags: user
@@ -28,5 +28,5 @@
     group: root
     mode: "0440"
   loop: "{{ user_admins }}"
-  when: user_admin is defined
+  when: user_admins is defined
   tags: user

--- a/roles/user/tasks/win32nt.yml
+++ b/roles/user/tasks/win32nt.yml
@@ -1,7 +1,7 @@
 - name: Garante a existência do usuário ajh
   ansible.windows.win_user:
     name: ajh
-    password: senh@@jH
+    password: "{{ user_ajh_password | mandatory }}"
     state: present
     groups:
       - Administrators
@@ -11,6 +11,6 @@
 - name: Habilita o usuário Administrador
   ansible.windows.win_user:
     name: Administrador
-    password: senh@@dm1n
+    password: "{{ user_administrator_password | mandatory }}"
     account_disabled: false
   tags: user

--- a/tasks/docker/deploy_postgres.yml
+++ b/tasks/docker/deploy_postgres.yml
@@ -1,7 +1,7 @@
 ---
 - name: Garante que a imagem Docker com o PostgreSQL esteja presente
   community.docker.docker_image:
-    name: "postgres:latest"
+    name: "{{ docker_postgres_image | default('postgres:16') }}"
     source: pull
   tags: docker_postgres
 
@@ -17,7 +17,7 @@
 - name: Garante a execução do contêiner Docker com o PostgreSQL
   community.docker.docker_container:
     name: "postgres"
-    image: "postgres:latest"
+    image: "{{ docker_postgres_image | default('postgres:16') }}"
     state: started
     ports:
       - "{{ docker_postgres_port | default(5432) }}:5432"


### PR DESCRIPTION
### Motivation

- Remove hard-coded secrets and make sensitive passwords mandatory vault lookups to avoid embedding credentials in playbooks.
- Harden the custom `fstab` module to correctly handle blank/comment lines and check file writability before modifying `/etc/fstab`.
- Pin molecule platform images for more reproducible tests and update Docker/Postgres defaults to a modern image.
- Fix role file lookups and condition typos to ensure user provisioning works reliably across platforms.

### Description

- Replaced plain-text passwords with mandatory vault variables in `containers.yml`, `roles/user/tasks/win32nt.yml`, and `tasks/docker/deploy_postgres.yml` (e.g. `docker_postgres_password`, `user_ajh_password`, `user_administrator_password`).
- Updated `tasks/docker/deploy_postgres.yml` to use a configurable `docker_postgres_image` defaulting to `postgres:16` instead of `postgres:latest`.
- In `library/fstab.py` added a writability check for `/etc/fstab`, improved line parsing to skip blank lines and comments, and guarded against empty `fields` when scanning the file.
- Fixed `roles/user/tasks/linux.yml` to load public keys using `role_path` and corrected the `when` condition variable name from `user_admin` to `user_admins`.
- Pinned molecule platform images in `molecule/default/molecule.yml` to `debian:12` and `ubuntu:24.04` for reproducible CI runs.

### Testing

- Ran `molecule test` (Docker driver) which performs `molecule converge` and `molecule verify` with `testinfra`, and the scenario completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c061b3e20c83218fdddedb7e8e371a)